### PR TITLE
(maint) Set resolve_reference task to private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## Release 0.2.0
+
+### New features
+
+* **Set `resolve_reference` task to private** ([#1](https://github.com/puppetlabs/puppetlabs-terraform/pulls/1))
+
+    The `resolve_reference` task has been set to `private` so it no longer appears in UI lists.
+
+## Release 0.1.0
+
+This is the initial release.

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -7,5 +7,6 @@
       "description": "The path to the YAML file"
     }
   },
-  "files": ["ruby_task_helper/files/task_helper.rb"]
+  "files": ["ruby_task_helper/files/task_helper.rb"],
+  "private": true
 }


### PR DESCRIPTION
This sets the `resolve_reference` task to private so it doesn't appear
in a task list when using `bolt task show`.

Part of puppetlabs/bolt#1599